### PR TITLE
Remove os constraint due to platform-agnostic type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,6 @@
     "shutdown",
     "SIGINT"
   ],
-  "os": [
-    "win32"
-  ],
   "engines": {
     "node": ">=8"
   },


### PR DESCRIPTION
This pr removes the os constraint because the type definitions included in the package are needed for type checking on Linux of multi-platform scripts using it, and removing the os constraint allows installation of the package on Linux without have to use `--force`.

Maybe this is a situation where the type definitions are better placed on the DefinitelyTyped monorepo?