### PR TITLE
feat: Remove TypeScript type definitions

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,4 +1,0 @@
-export declare function generateCtrlC(): boolean;
-export declare function generateCtrlCAsync(): Promise<boolean>;
-export declare function generateCtrlBreak(dwProcessGroupId?: number): boolean;
-export declare function generateCtrlBreakAsync(dwProcessGroupId?: number): Promise<boolean>;

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "generate-ctrl-c-event.ps1"
   ],
   "main": "lib/index.js",
-  "typings": "lib/index.d.ts",
   "dependencies": {},
   "optionalDependencies": {
     "ffi-napi": "^3.0.1"
@@ -43,8 +42,7 @@
     "@semantic-release/git": "^9.0.0",
     "eslint": "^7.22.0",
     "eslint-config-zenflow": "^3.0.0",
-    "semantic-release": "^17.4.2",
-    "typescript": "^4.2.3"
+    "semantic-release": "^17.4.2"
   },
   "scripts": {
     "lint": "eslint .",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5468,11 +5468,6 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.3.tgz#39062d8019912d43726298f09493d598048c1ce3"
-  integrity sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==
-
 uglify-js@^3.1.4:
   version "3.13.2"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.13.2.tgz#fe10319861bccc8682bfe2e8151fbdd8aa921c44"


### PR DESCRIPTION
This reverts commit 6c701a29754bf82c7128f50e48b556a4c7192afb.

BREAKING CHANGE: TS type definitions have been removed

If you need TS types for this package, install the `@types/generate-ctrl-c-event` package.


Related issue: #9

---

Merging this will trigger the release of the next major version (v2.0.0).

@kazarmy Please approve