### PR TITLE
Set `-ExecutionPolicy Bypass` on PowerShell script execution

### DIFF
--- a/lib/GenerateConsoleCtrlEvent.js
+++ b/lib/GenerateConsoleCtrlEvent.js
@@ -28,7 +28,13 @@ const GenerateConsoleCtrlEvent = kernel32
       (...args) => promisify(cp.execFile)(...args).then(({ stdout }) => stdout),
       (args) => [
         "powershell.exe",
-        ["-File", path.join(__dirname, "..", "generate-ctrl-event.ps1"), ...args],
+        [
+          "-ExecutionPolicy",
+          "Bypass",
+          "-File",
+          path.join(__dirname, "..", "generate-ctrl-event.ps1"),
+          ...args,
+        ],
         { stdio: ["ignore", "pipe", "pipe"] },
       ],
       (buffer) => {


### PR DESCRIPTION
This PR sets `-ExecutionPolicy Bypass` when executing the PowerShell script of `generate-ctrl-event.ps1`. This is because the [default execution policy](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_execution_policies?view=powershell-5.1#powershell-execution-policies) (`Undefined`, which is equivalent to `Restricted` on Windows clients) prevents script execution.